### PR TITLE
Allow to set a optional CSS class for a menu item

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -135,9 +135,11 @@ if (Tools::isSubmit('token') && Tools::getValue('token') == $goodToken) {
         $link = htmlspecialchars(Tools::getValue('link'));
         $label = htmlspecialchars(Tools::getValue('label'));
         $target = htmlspecialchars(Tools::getValue('target'));
+        $cssclass = htmlspecialchars(Tools::getValue('cssclass'));
         
         $module->menu_model->type       = "custom_link";
         $module->menu_model->target     = $target;
+        $module->menu_model->cssclass   = $cssclass;
         $module->menu_model->url_engine = false;
         $module->menu_model->id_parent  = 0;
         
@@ -223,10 +225,12 @@ if (Tools::isSubmit('token') && Tools::getValue('token') == $goodToken) {
         // $link = htmlspecialchars(Tools::getValue('link'));
         $label = htmlspecialchars(Tools::getValue('label'));
         $target = htmlspecialchars(Tools::getValue('target'));
+        $cssclass = htmlspecialchars(Tools::getValue('cssclass'));
         $id_product = (int)Tools::getValue('id_product');
         
         $module->menu_model->type       = "product";
         $module->menu_model->target     = $target;
+        $module->menu_model->cssclass   = $cssclass;
         $module->menu_model->url_engine = false;
         $module->menu_model->id_parent  = 0;
         
@@ -378,7 +382,8 @@ if (Tools::isSubmit('token') && Tools::getValue('token') == $goodToken) {
                                         $item->id_silo = (int)Tools::getValue('silo');
                                     }
                                     
-                                    $item->target           = pSQL((string)Tools::getValue('target'));
+                                    $item->target           = stripslashes(pSQL((string)Tools::getValue('target')));
+                                    $item->cssclass         = pSQL((string)Tools::getValue('cssclass'));
                                     $item->display_sections[$id_lang] = $display_sections;
                                     
                                     if ($item->save()) {

--- a/models/SeoprestamenuModel.php
+++ b/models/SeoprestamenuModel.php
@@ -30,6 +30,8 @@ class SeoprestamenuModel extends ObjectModel
     public $type;
 
     public $target;
+    
+    public $cssclass;
 
     public $url_engine;
 
@@ -61,6 +63,7 @@ class SeoprestamenuModel extends ObjectModel
         'fields' => array(
             'type'          => array('type' => self::TYPE_STRING,  'size' => 255, 'required' => true),
             'target'        => array('type' => self::TYPE_STRING),
+            'cssclass'        => array('type' => self::TYPE_STRING),
             'url_engine'    => array('type' => self::TYPE_BOOL),
 
             'id_parent'     => array('type' => self::TYPE_INT),

--- a/sql/install.php
+++ b/sql/install.php
@@ -30,6 +30,7 @@ $sql[] = 'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'seoprestamenu_item` (
   `id_item` int(11) NOT NULL,
   `type` varchar(255) NOT NULL,
   `target` varchar(255) NOT NULL,
+  `cssclass` varchar(255) NOT NULL,
   `url_engine` tinyint(1) NOT NULL DEFAULT 0,
   `id_parent` int(11) NOT NULL DEFAULT 0,
   `id_silo` int(11) NOT NULL DEFAULT 0,

--- a/translations/fr.php
+++ b/translations/fr.php
@@ -12,6 +12,7 @@ $_MODULE['<{seoprestamenu}prestashop>ajax_form_details_02a3a357710cc2a5dfdfb74ed
 $_MODULE['<{seoprestamenu}prestashop>ajax_form_details_c41a31890959544c6523af684561abe5'] = 'Cible';
 $_MODULE['<{seoprestamenu}prestashop>ajax_form_details_572898e06a331602937faebe89736b0b'] = 'Dans le même onglet';
 $_MODULE['<{seoprestamenu}prestashop>ajax_form_details_041a1d8d6f1063c9fea0271e4224b721'] = 'Dans un autre onglet';
+$_MODULE['<{seoprestamenu}prestashop>ajax_form_details_f55504fc467a2b7b921506b9fe40f710'] = 'Classe CSS';
 $_MODULE['<{seoprestamenu}prestashop>ajax_form_details_a6d9fdcd12e6c9101fcc0d3517dde2f7'] = 'Affichage en section (type mega menu)';
 $_MODULE['<{seoprestamenu}prestashop>ajax_form_details_06933067aafd48425d67bcb01bba5cb6'] = 'Sauvegarder';
 $_MODULE['<{seoprestamenu}prestashop>configure_6ed9fc80fb74e510479474d14cdd9187'] = 'Voulez vous supprimer le(e) élément(s)';
@@ -34,6 +35,8 @@ $_MODULE['<{seoprestamenu}prestashop>configure_54d555b5782f3e9e45091d7064f9a964'
 $_MODULE['<{seoprestamenu}prestashop>configure_c41a31890959544c6523af684561abe5'] = 'Cible';
 $_MODULE['<{seoprestamenu}prestashop>configure_572898e06a331602937faebe89736b0b'] = 'Dans le même onglet';
 $_MODULE['<{seoprestamenu}prestashop>configure_041a1d8d6f1063c9fea0271e4224b721'] = 'Dans un autre onglet';
+$_MODULE['<{seoprestamenu}prestashop>configure_f55504fc467a2b7b921506b9fe40f710'] = 'Classe CSS';
+$_MODULE['<{seoprestamenu}prestashop>configure_771b6e144110759e23e12c5c20107ef9'] = 'Classe CSS facultative';
 $_MODULE['<{seoprestamenu}prestashop>configure_068f80c7519d0528fb08e82137a72131'] = 'Produits';
 $_MODULE['<{seoprestamenu}prestashop>configure_08fce3fbcd5f653e92da81b1366ddf7c'] = 'Rechercher par nom...';
 $_MODULE['<{seoprestamenu}prestashop>configure_d304ba20e96d87411588eeabac850e34'] = 'Label';
@@ -41,7 +44,5 @@ $_MODULE['<{seoprestamenu}prestashop>configure_2a304a1348456ccd2234cd71a81bd338'
 $_MODULE['<{seoprestamenu}prestashop>configure_8a6659f67cb5dc1b775ab7b9a22fd9a1'] = 'Ajouter un produit au menu';
 $_MODULE['<{seoprestamenu}prestashop>configure_3a08e2e340ab29fd9263af48193cbf8e'] = 'Langues';
 $_MODULE['<{seoprestamenu}prestashop>configure_c8ddf0daeb972422159148fda3c3fa56'] = 'Supprimer le(s) élément(s)';
-$_MODULE['<{seoprestamenu}prestashop>configure_8524de963f07201e5c086830d370797f'] = 'Chargement...';
 $_MODULE['<{seoprestamenu}prestashop>configure_f692973556248ff9ef223e21fb42852a'] = 'Sauvegarder le menu';
 $_MODULE['<{seoprestamenu}prestashop>menu_1ff51c1fa6c2cb5e8feacad02e9a6fb1'] = 'Pas d\'éléments dans le menu';
-$_MODULE['<{seoprestamenu}prestashop>displaynavfullwidth_846495f9ceed11accf8879f555936a7d'] = 'Navigation';

--- a/views/templates/admin/ajax_form_details.tpl
+++ b/views/templates/admin/ajax_form_details.tpl
@@ -21,6 +21,10 @@
         <option value="_blank" {if isset($item->target) && $item->target == '_blank'} selected {/if} >{l s='In other tab' mod='seoprestamenu'}</option>
       </select>
     </div>
+    <div class="form-group sweet-modal-prompt">
+      <label for="">{l s='CSS class' mod='seoprestamenu'}</label>
+      <input type="text" class="form-control" name="cssclass" value="{if isset($item->cssclass)}{$item->cssclass}{/if}">
+    </div>
     {if $helperMenu->menu_model->getChilden($item->id,$id_lang)|count > 0}
     <div class="form-group sweet-modal-prompt">
       <label for="">{l s='Display in section' mod='seoprestamenu'}</label>

--- a/views/templates/admin/configure.tpl
+++ b/views/templates/admin/configure.tpl
@@ -118,6 +118,12 @@
 									</select>
 								</div>
 
+								<!-- CSS class -->
+								<div class="form-group">
+									<label for="">{l s='CSS class' mod='seoprestamenu'}</label>
+									<input type="text" name="cssclass" placeholder="{l s='Optional CSS class' mod='seoprestamenu'}">
+								</div>
+
 								<button type="submit" class="btn btn-primary  pointer pull-right " name="addCustomLink" id="addCustomLink">{l s='Add item in menu' mod='seoprestamenu'}</button>
 								<div class="clearfix"></div>
 							</form>
@@ -156,6 +162,12 @@
 											<option value="_self">{l s='In the current tab' mod='seoprestamenu'}</option>
 											<option value="_blank">{l s='In other tab' mod='seoprestamenu'}</option>
 										</select>
+									</div>
+
+									<!-- CSS class -->
+									<div class="form-group">
+										<label for="">{l s='CSS class' mod='seoprestamenu'}</label>
+										<input type="text" name="cssclass" id="cssclass">
 									</div>
 
 									<button type="submit" class="btn btn-primary  pointer pull-right" name="addProductMenu" id="addProductMenu">{l s='Add product in menu' mod='seoprestamenu'}

--- a/views/templates/hooks/item-front.tpl
+++ b/views/templates/hooks/item-front.tpl
@@ -1,7 +1,7 @@
 {$childrens = array()}
 {$childrens = $helperMenu->menu_model->getChilden($item.id_item,$helperMenu->current_lang)}
 
-<li id="menu-item-{$item.id_item}" class="{if $item.display_sections}mega-menu{/if} {if $item.id_parent == 0}current-menu-parent{/if} {if $childrens|count > 0}menu-item-has-children{/if}">
+<li id="menu-item-{$item.id_item}" class="{if $item.display_sections}mega-menu{/if} {if $item.id_parent == 0}current-menu-parent{/if} {if $childrens|count > 0}menu-item-has-children{/if} {if $item.cssclass}{$item.cssclass}{/if}">
 <a href="{$item.url}" {if $item.target != null}target="{$item.target}"{/if}>{$item.label}</a>
 
 {if $childrens|count > 0}

--- a/views/templates/hooks/item-mobile-front.tpl
+++ b/views/templates/hooks/item-mobile-front.tpl
@@ -1,7 +1,7 @@
 {$childrens = array()}
 {$childrens = $helperMenu->menu_model->getChilden($item.id_item,$helperMenu->current_lang)}
 
-<li id="menu-item-{$item.id_item}" class="mega-menu multi-column  {if $item.id_parent == 0}column_3{/if} menu-item menu-item-type-taxonomy menu-item-object-category {if $childrens|count > 0}menu-item-has-children{/if} menu-item-{$item.id_item}">
+<li id="menu-item-{$item.id_item}" class="mega-menu multi-column  {if $item.id_parent == 0}column_3{/if} menu-item menu-item-type-taxonomy menu-item-object-category {if $childrens|count > 0}menu-item-has-children{/if} menu-item-{$item.id_item} {if $item.cssclass}{$item.cssclass}{/if}">
   <a href="{$item.url}" {if $item.target != null}target="{$item.target}"{/if}>{$item.label}</a>
 
 {if $childrens|count > 0}


### PR DESCRIPTION
This PR adds a text field for setting a css class for a menu item.
This can be usefull to change a menu style (color, button style) or to add an icon for some items.

I've add the cssclass column in seoprestamenu_item table. So the module needs to be reinitialised to have the sql creation requests executed.

Cf issue https://github.com/PrestaShop/seoprestamenu/issues/26